### PR TITLE
Feature/api custom routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,8 +340,32 @@ db = client["mydb"]
 
 start_api(db)
 ```
-
 This will start a REST API server with Swagger documentation at http://127.0.0.1:8000/docs
+
+
+## 🔌 Custom API Endpoints
+
+You can extend the auto-generated API with your own custom routes using the extra_routes parameter in start_api.
+
+### ➕ Example
+
+```python
+from fastapi import APIRouter
+from mso.api import start_api
+
+custom_router = APIRouter()
+
+@custom_router.get("/people/stats", tags=["People"])
+def get_people_stats():
+    return {"message": "Custom stats for the People collection"}
+
+start_api(
+    db=db,
+    collections=["*"],
+    extra_routes=custom_router
+)
+```
+
 
 # 🔗 Community & Links
 PyPi: https://pypi.org/project/MSO/

--- a/README.md
+++ b/README.md
@@ -353,12 +353,18 @@ You can extend the auto-generated API with your own custom routes using the extr
 from fastapi import APIRouter
 from mso.api import start_api
 
+# Connect to MongoDB
+client = MongoClient("mongodb://localhost:27017")
+db = client["mydb"]
+
+# Define your custom routes
 custom_router = APIRouter()
 
 @custom_router.get("/people/stats", tags=["People"])
 def get_people_stats():
     return {"message": "Custom stats for the People collection"}
 
+# Start the API with custom routes
 start_api(
     db=db,
     collections=["*"],

--- a/examples/launch_api.py
+++ b/examples/launch_api.py
@@ -11,19 +11,11 @@
 #                                                                                                                      #
 #  Gitlab: https://github.com/chuckbeyor101/MSO-Mongo-Schema-Object-Library                                            #
 # ######################################################################################################################
-from operator import truediv
 
 from pymongo import MongoClient
 from mso.api import start_api
-from fastapi import HTTPException
+from fastapi import APIRouter
 import os
-
-
-async def authenticate(request):
-    authorized = True
-
-    if not authorized:
-        raise HTTPException(status_code=401, detail="Unauthorized")
 
 MONGO_URI = os.getenv("MONGO_URI", "mongodb://localhost:27017")
 MONGO_DB = os.getenv("MONGO_DB", "mydb")
@@ -31,4 +23,12 @@ MONGO_DB = os.getenv("MONGO_DB", "mydb")
 client = MongoClient(MONGO_URI)
 db = client[MONGO_DB]
 
-start_api(db, debug=False, auth_func=authenticate)
+custom_router = APIRouter()
+
+
+@custom_router.get("/hello", tags=["Custom Routes"])
+def say_hello():
+    return {"message": "Hello from a custom route!"}
+
+
+start_api(db, extra_routes=custom_router)

--- a/mso/api.py
+++ b/mso/api.py
@@ -360,6 +360,7 @@ def start_api(
     pretty_tags: bool = True,
     limit_default=20,
     limit_max=1000,
+    extra_routes: Union[APIRouter, List[APIRouter]] = None,
     **uvicorn_kwargs
 ):
     """
@@ -388,6 +389,7 @@ def start_api(
             pretty_tags (bool): Whether to use prettified tags in the OpenAPI docs.
             limit_default (int): Default page size for paginated routes.
             limit_max (int): Maximum page size for paginated routes.
+            extra_routes (APIRouter or list of APIRouter, optional): Additional FastAPI routers to include.
             **uvicorn_kwargs: Additional keyword arguments passed to `uvicorn.run()`.
 
         Behavior:
@@ -449,5 +451,13 @@ def start_api(
         else:
             print(f"Registering routes for collection: {name}") if debug else None
             add_api_routes(app, name, Model, auth_func=auth_func, debug=debug, read_only=False, limit_default=limit_default, limit_max=limit_max, pretty_tags=pretty_tags)
+
+    # Register any additional routes provided
+    if extra_routes:
+        if isinstance(extra_routes, list):
+            for router in extra_routes:
+                app.include_router(router)
+        else:
+            app.include_router(extra_routes)
 
     uvicorn.run(app, host=host, port=port, **uvicorn_kwargs)


### PR DESCRIPTION
## 🔌 Custom API Endpoints

You can extend the auto-generated API with your own custom routes using the extra_routes parameter in start_api.

### ➕ Example

```python
from fastapi import APIRouter
from mso.api import start_api

# Connect to MongoDB
client = MongoClient("mongodb://localhost:27017")
db = client["mydb"]

# Define your custom routes
custom_router = APIRouter()

@custom_router.get("/people/stats", tags=["People"])
def get_people_stats():
    return {"message": "Custom stats for the People collection"}

# Start the API with custom routes
start_api(
    db=db,
    collections=["*"],
    extra_routes=custom_router
)
```